### PR TITLE
remove unused $NAME variable

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,7 +98,7 @@ installFile() {
   TMPDIR="/tmp/$PROJECT_NAME"
   mkdir -p "$TMPDIR"
   tar xf "$TMP_CACHE_FILE" -C "$TMPDIR"
-  TMPDIR_BIN="$TMPDIR/$OS-$ARCH/$NAME"
+  TMPDIR_BIN="$TMPDIR/$OS-$ARCH"
   echo "Preparing to install into ${INSTALL_PREFIX}"
   # Use * to also copy the file withe the exe suffix on Windows
   sudo mkdir -p "$INSTALL_PREFIX"


### PR DESCRIPTION
This variable is not used by the script so normally it has no effect, but when $NAME is set in the user's environment, it can wreak havoc on the install script.

fixes #89 