### PR TITLE
Make SHA256 comparison case insensitive

### DIFF
--- a/food.go
+++ b/food.go
@@ -333,7 +333,7 @@ func checksumVerifyPath(path string, checksum string) error {
 	}
 
 	actualChecksum := fmt.Sprintf("%x", hasher.Sum(nil))
-	if strings.Compare(actualChecksum, checksum) != 0 {
+	if strings.Compare(actualChecksum, strings.ToLower(checksum)) != 0 {
 		return fmt.Errorf("checksums differ for %s: expected '%s', got '%s'", path, checksum, actualChecksum)
 	}
 	return nil


### PR DESCRIPTION
hasher.Sum always returns lowercase for a-f, but some tools like PowerShell's `Get-FileHash -Algorithm SHA256` return uppercase A-F.

This normalizes to lowercase before comparison.