### PR TITLE
Issue 113 upgrade added rigs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,47 +3,36 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f9599d72b531f34dc0901d09005219566df459e0bae06c750e3eebf4bf2af939"
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  pruneopts = ""
   revision = "3c560837130448941620d7694991d3ec440aefc0"
 
 [[projects]]
-  digest = "1:feba416f3ee4dff9898e111bf1c6e30caba339cf39e9f38e5c395d156ed19302"
   name = "github.com/Masterminds/vcs"
   packages = ["."]
-  pruneopts = ""
   revision = "6f1c6d150500e452704e9863f68c2559f58616bf"
   version = "v1.12.0"
 
 [[projects]]
-  digest = "1:6331095c1906771fbe129fe4a1f94ac5b5a97b0f60f2f80653bb95c3e5dad81e"
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  pruneopts = ""
   revision = "7da180ee92d8bd8bb8c37fc560e673e6557c392f"
   version = "v0.4.7"
 
 [[projects]]
-  digest = "1:9d013c04ff3012769abc7ea289948bf93bf82e8b22c5909f031127647609523f"
   name = "github.com/bacongobbler/browser"
   packages = ["."]
-  pruneopts = ""
   revision = "792d0443b3e34e0a99a68e254084079ad9356db5"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:96843e93d86862260d76d1ba589e988b62be6aa26fb8eb7e0d9d301c33fc194f"
   name = "github.com/containerd/continuity"
   packages = ["pathdriver"]
-  pruneopts = ""
   revision = "c6cef34830231743494fe2969284df7b82cc0ad0"
 
 [[projects]]
   branch = "master"
-  digest = "1:5fcfd7c83aa89c5cbe9682f04306c8745cf7c8ea1b3d8467253efcb5b6775394"
   name = "github.com/docker/docker"
   packages = [
     "pkg/archive",
@@ -53,196 +42,145 @@
     "pkg/longpath",
     "pkg/mount",
     "pkg/pools",
-    "pkg/system",
+    "pkg/system"
   ]
-  pruneopts = ""
   revision = "cf9c48bb3ecf47ed56a4b7b466eda577913f838e"
 
 [[projects]]
-  digest = "1:582d54fcb7233da8dde1dfd2210a5b9675d0685f84246a8d317b07d680c18b1b"
   name = "github.com/docker/go-units"
   packages = ["."]
-  pruneopts = ""
   revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
   version = "v0.3.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:b4e7b1e55d849b7d1a4d96d1a029141d7ac963b4403e6ddb1cdb6e5384ab4781"
   name = "github.com/gosuri/uitable"
   packages = [
     ".",
     "util/strutil",
-    "util/wordwrap",
+    "util/wordwrap"
   ]
-  pruneopts = ""
   revision = "36ee7e946282a3fb1cfecd476ddc9b35d8847e42"
 
 [[projects]]
-  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:41ea0e53c25c1c7f51b3ff6589bcf586a0fb548caceeb6a5dd60b91ed19ea801"
   name = "github.com/kyokomi/emoji"
   packages = ["."]
-  pruneopts = ""
   revision = "2e9a9507333f3ee28f3fab88c2c3aba34455d734"
 
 [[projects]]
-  digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
-  pruneopts = ""
   revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
   version = "v0.0.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:59fa50d593e5673a0dfffa1852b66fd700c05b35e368680b4b89a68fdb2c1379"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = ""
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
-  digest = "1:5d9b668b0b4581a978f07e7d2e3314af18eb27b3fb5d19b70185b7c575723d11"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
-  pruneopts = ""
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
-  digest = "1:f26c8670b11e29a49c8e45f7ec7f2d5bac62e8fd4e3c0ae1662baa4a697f984a"
   name = "github.com/opencontainers/image-spec"
   packages = [
     "specs-go",
-    "specs-go/v1",
+    "specs-go/v1"
   ]
-  pruneopts = ""
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:fa19ddee0e5ee5951a6a450a4b6ec635a42957f86bfc87d9d778eeee04ad2036"
   name = "github.com/opencontainers/runc"
   packages = [
     "libcontainer/system",
-    "libcontainer/user",
+    "libcontainer/user"
   ]
-  pruneopts = ""
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:54b56e41fbe67fa032aef3c985939ca17a61f0c21fd81aee753018f8f3f70889"
   name = "github.com/renstrom/fuzzysearch"
   packages = ["fuzzy"]
-  pruneopts = ""
   revision = "d4ca9dfccd55dc6b076f9880d49c35315922c1f4"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:8cf46b6c18a91068d446e26b67512cf16f1540b45d90b28b9533706a127f0ca6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = ""
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:74c32990510c9f188556aa17600313e867d1d06f5a9db244056a95d144ec34ce"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  pruneopts = ""
   revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
   version = "v0.0.2"
 
 [[projects]]
-  digest = "1:8e243c568f36b09031ec18dff5f7d2769dcf5ca4d624ea511c8e3197dc3d352d"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = ""
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:1d5723b1cc92c8c98462214781c0678010e120eaf1fa941779bd12b206a6a719"
   name = "github.com/yuin/gluamapper"
   packages = ["."]
-  pruneopts = ""
   revision = "d836955830e75240d46ce9f0e6d148d94f2e1d3a"
 
 [[projects]]
   branch = "master"
-  digest = "1:b7bd7ea0cd580bb41608de12827d49154d7115f844af01f8ee51f38d5e32459e"
   name = "github.com/yuin/gopher-lua"
   packages = [
     ".",
     "ast",
     "parse",
-    "pm",
+    "pm"
   ]
-  pruneopts = ""
   revision = "b0fa786cf4ea360285924c4a7fd42325be57aec8"
 
 [[projects]]
   branch = "master"
-  digest = "1:e03c8afd6f75c7349451fbfef3f548f845d3fda097af28d6144a725023c1ce1a"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = ""
   revision = "e73bf333ef8920dbb52ad18d4bd38ad9d9bc76d7"
 
 [[projects]]
   branch = "master"
-  digest = "1:80ec738f420f13c23460cc92cd893d3e403588c60682afebbd4515eca5e19578"
   name = "golang.org/x/net"
   packages = ["context"]
-  pruneopts = ""
   revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
 
 [[projects]]
   branch = "master"
-  digest = "1:e947dc04c62cf4cca2b3b137d3f266fb592f5de429b9e18c0c3018df0eb78c76"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = ""
   revision = "79b0c6888797020a994db17c8510466c72fe75d9"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Masterminds/semver",
-    "github.com/Masterminds/vcs",
-    "github.com/bacongobbler/browser",
-    "github.com/docker/docker/pkg/archive",
-    "github.com/gosuri/uitable",
-    "github.com/kyokomi/emoji",
-    "github.com/renstrom/fuzzysearch/fuzzy",
-    "github.com/sirupsen/logrus",
-    "github.com/spf13/cobra",
-    "github.com/yuin/gluamapper",
-    "github.com/yuin/gopher-lua",
-  ]
+  inputs-digest = "217cb1350a256657ccbc1b19466fd433a6747426496c3720e8a2bcddcefb2e1c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -181,6 +181,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "217cb1350a256657ccbc1b19466fd433a6747426496c3720e8a2bcddcefb2e1c"
+  inputs-digest = "4fb57e5278addb364162e179ebea02a42e8fc0cd3588d7ee214d651ed10327e5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/gofish/cleanup.go
+++ b/cmd/gofish/cleanup.go
@@ -10,7 +10,7 @@ func newCleanupCmd() *cobra.Command {
 		Use:   "cleanup",
 		Short: "cleanup unlinked fish food",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			for _, name := range findFood() {
+			for _, name := range findFood([]string{}) {
 				versions := findFoodVersions(name)
 				if len(versions) > 1 {
 					for _, ver := range versions {

--- a/cmd/gofish/list.go
+++ b/cmd/gofish/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/fishworks/gofish"
 	"github.com/gosuri/uitable"
@@ -54,7 +55,13 @@ func findFood() []string {
 				continue
 			}
 			if len(files) > 0 {
-				fudz = append(fudz, f.Name())
+				fileName := f.Name()
+				rigConf, err := ioutil.ReadFile(filepath.Join(barrelPath, f.Name()) + "/rig.conf")
+				if err == nil {
+					location := strings.TrimSpace(string(rigConf))
+					fileName = strings.Join([]string{location, fileName}, "/")
+				}
+				fudz = append(fudz, fileName)
 			}
 		}
 	}

--- a/cmd/gofish/rotten.go
+++ b/cmd/gofish/rotten.go
@@ -15,7 +15,7 @@ func newRottenCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			table := uitable.New()
 			table.AddRow("NAME", "VERSION")
-			for _, name := range findFood() {
+			for _, name := range findFood([]string{}) {
 				versions := findFoodVersions(name)
 				if len(versions) > 1 {
 					for _, ver := range versions {

--- a/cmd/gofish/upgrade.go
+++ b/cmd/gofish/upgrade.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -25,7 +26,13 @@ func newUpgradeCmd() *cobra.Command {
 			}
 			nothingUpgraded := true
 			for _, name := range foodNames {
-				installedVersions := findFoodVersions(name)
+				// Check the Barrel name for version
+				foodInfo := strings.Split(name, "/")
+				nameVer := foodInfo[len(foodInfo)-1]
+				if len(foodInfo) == 1 {
+					nameVer = foodInfo[0]
+				}
+				installedVersions := findFoodVersions(nameVer)
 				vs := make(semver.Collection, len(installedVersions))
 				for i, r := range installedVersions {
 					v, err := semver.NewVersion(r)

--- a/cmd/gofish/upgrade.go
+++ b/cmd/gofish/upgrade.go
@@ -19,11 +19,8 @@ func newUpgradeCmd() *cobra.Command {
 				return err
 			}
 			var foodNames []string
-			if len(args) > 0 {
-				foodNames = args
-			} else {
-				foodNames = findFood()
-			}
+			foodNames = findFood(args)
+
 			nothingUpgraded := true
 			for _, name := range foodNames {
 				// Check the Barrel name for version

--- a/food.go
+++ b/food.go
@@ -86,6 +86,8 @@ func (f *Food) Install() error {
 	if err := os.MkdirAll(barrelDir, 0755); err != nil {
 		return err
 	}
+	// Add a conf file with the rig that the file comes from.
+	err = ioutil.WriteFile(strings.Join([]string{Home(HomePath).Barrel(), f.Name, "rig.conf"}, "/"), []byte(f.Rig), 0644)
 	unarchiveOrCopy(cachedFilePath, barrelDir, u.Path)
 
 	// This is just a safety check to make sure that there's nothing there when we link the package.

--- a/food.go
+++ b/food.go
@@ -88,6 +88,9 @@ func (f *Food) Install() error {
 	}
 	// Add a conf file with the rig that the file comes from.
 	err = ioutil.WriteFile(strings.Join([]string{Home(HomePath).Barrel(), f.Name, "rig.conf"}, "/"), []byte(f.Rig), 0644)
+	if err != nil {
+		return err
+	}
 	unarchiveOrCopy(cachedFilePath, barrelDir, u.Path)
 
 	// This is just a safety check to make sure that there's nothing there when we link the package.


### PR DESCRIPTION
Allows the use of added rigs and updating
Provides a rig.conf that details which rig the food were installed from.
Currently, the rig.conf is simply adding the rig and no other values.