### PR TITLE
introduce install receipts

### DIFF
--- a/cmd/gofish/create.go
+++ b/cmd/gofish/create.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +70,7 @@ func newCreateCmd() *cobra.Command {
 		Short: "generate fish food and open it in the editor",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home := gofish.Home(gofish.HomePath)
+			home := home.Home(home.HomePath)
 			destPath := filepath.Join(home.Rigs(), home.DefaultRig(), "Food", fmt.Sprintf("%s.lua", args[0]))
 			f, err := os.Create(destPath)
 			if err != nil {

--- a/cmd/gofish/home.go
+++ b/cmd/gofish/home.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +18,7 @@ func newHomeCmd() *cobra.Command {
 		Short: "print the location of fish's home directory",
 		Long:  homeDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println(gofish.Home(gofish.HomePath))
+			fmt.Println(home.Home(home.HomePath))
 			return nil
 		},
 	}

--- a/cmd/gofish/init.go
+++ b/cmd/gofish/init.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/spf13/cobra"
 )
 
@@ -36,13 +36,13 @@ func newInitCmd() *cobra.Command {
 }
 
 func (i *initCmd) run() error {
-	home := gofish.Home(gofish.HomePath)
-	userHome := gofish.UserHome(gofish.UserHomePath)
+	h := home.Home(home.HomePath)
+	userHome := home.UserHome(home.UserHomePath)
 	dirs := []string{
-		home.String(),
-		home.Barrel(),
-		home.Rigs(),
-		gofish.BinPath,
+		h.String(),
+		h.Barrel(),
+		h.Rigs(),
+		home.BinPath,
 		userHome.Cache(),
 	}
 

--- a/cmd/gofish/list.go
+++ b/cmd/gofish/list.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 )
@@ -40,7 +41,7 @@ func newListCmd() *cobra.Command {
 }
 
 func findFood() []string {
-	barrelPath := gofish.Home(gofish.HomePath).Barrel()
+	barrelPath := home.Home(home.HomePath).Barrel()
 	var fudz []string
 	files, err := ioutil.ReadDir(barrelPath)
 	if err != nil {
@@ -62,7 +63,7 @@ func findFood() []string {
 }
 
 func findFoodVersions(name string) []string {
-	barrelPath := gofish.Home(gofish.HomePath).Barrel()
+	barrelPath := home.Home(home.HomePath).Barrel()
 	var versions []string
 	files, err := ioutil.ReadDir(filepath.Join(barrelPath, name))
 	if err != nil {

--- a/cmd/gofish/rig_add.go
+++ b/cmd/gofish/rig_add.go
@@ -3,9 +3,8 @@ package main
 import (
 	"time"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/ohai"
-
 	"github.com/fishworks/gofish/pkg/rig/installer"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +19,7 @@ func newRigAddCmd() *cobra.Command {
 			if len(args) > 1 {
 				name = args[1]
 			}
-			i, err := installer.New(args[0], name, "", gofish.Home(gofish.HomePath))
+			i, err := installer.New(args[0], name, "", home.Home(home.HomePath))
 			if err != nil {
 				return err
 			}

--- a/cmd/gofish/rig_list.go
+++ b/cmd/gofish/rig_list.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +16,7 @@ func newRigListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "list rigs",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rigPath := gofish.Home(gofish.HomePath).Rigs()
+			rigPath := home.Home(home.HomePath).Rigs()
 			rigs := findRigs(rigPath)
 
 			table := uitable.New()

--- a/cmd/gofish/rig_path.go
+++ b/cmd/gofish/rig_path.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/fishworks/gofish"
-
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +15,7 @@ func newRigPathCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
-			home := gofish.Home(gofish.HomePath)
+			home := home.Home(home.HomePath)
 			fmt.Println(filepath.Join(home.Rigs(), name))
 		},
 	}

--- a/cmd/gofish/rig_remove.go
+++ b/cmd/gofish/rig_remove.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/ohai"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +16,7 @@ func newRigRemoveCmd() *cobra.Command {
 		Short: "remove rigs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			start := time.Now()
-			rigPath := gofish.Home(gofish.HomePath).Rigs()
+			rigPath := home.Home(home.HomePath).Rigs()
 			rigs := findRigs(rigPath)
 			foundRigs := map[string]bool{}
 			for _, arg := range args {

--- a/cmd/gofish/search.go
+++ b/cmd/gofish/search.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/gosuri/uitable"
 	"github.com/renstrom/fuzzysearch/fuzzy"
 	log "github.com/sirupsen/logrus"
@@ -61,7 +61,7 @@ func search(keywords []string) []string {
 }
 
 func findFishFood() []string {
-	home := gofish.Home(gofish.HomePath)
+	home := home.Home(home.HomePath)
 	rigPath := home.Rigs()
 	var fudz []string
 	filepath.Walk(rigPath, func(p string, f os.FileInfo, err error) error {

--- a/cmd/gofish/search_test.go
+++ b/cmd/gofish/search_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 )
 
 func TestSearch(t *testing.T) {
@@ -15,7 +15,7 @@ func TestSearch(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	gofish.HomePath = filepath.Join(cwd, "testdata")
+	home.HomePath = filepath.Join(cwd, "testdata")
 
 	expectedFoodList := []string{
 		"github.com/customorg/fish-food/hugo",

--- a/cmd/gofish/tank.go
+++ b/cmd/gofish/tank.go
@@ -3,14 +3,14 @@ package main
 import (
 	"path/filepath"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 )
 
 type tank map[string]string
 
 func (t tank) fill() {
-	fishHome := gofish.Home(gofish.HomePath)
-	userHome := gofish.UserHome(gofish.UserHomePath)
+	fishHome := home.Home(home.HomePath)
+	userHome := home.UserHome(home.UserHomePath)
 
 	t["GOFISH_HOME"] = fishHome.String()
 	t["GOFISH_CACHE"] = userHome.Cache()

--- a/cmd/gofish/tank_test.go
+++ b/cmd/gofish/tank_test.go
@@ -6,11 +6,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 )
 
 func TestTankFill(t *testing.T) {
-	gofish.HomePath = "/usr/local/Fish"
+	home.HomePath = "/usr/local/Fish"
 	expectedTank := tank{
 		"GOFISH_HOME":        "/usr/local/Fish",
 		"GOFISH_BARREL":      "/usr/local/Fish/Barrel",
@@ -19,7 +19,7 @@ func TestTankFill(t *testing.T) {
 	}
 
 	if runtime.GOOS == "windows" {
-		gofish.HomePath = "C:\\Fish"
+		home.HomePath = "C:\\Fish"
 		expectedTank["GOFISH_HOME"] = "C:\\Fish"
 		expectedTank["GOFISH_BARREL"] = "C:\\Fish\\Barrel"
 		expectedTank["GOFISH_RIGS"] = "C:\\Fish\\Rigs"
@@ -28,11 +28,11 @@ func TestTankFill(t *testing.T) {
 
 	switch runtime.GOOS {
 	case "darwin":
-		expectedTank["GOFISH_CACHE"] = filepath.Join(gofish.UserHomePath, "Library", "Caches", "Fish")
+		expectedTank["GOFISH_CACHE"] = filepath.Join(home.UserHomePath, "Library", "Caches", "Fish")
 	case "linux":
-		expectedTank["GOFISH_CACHE"] = filepath.Join(gofish.UserHomePath, ".gofish")
+		expectedTank["GOFISH_CACHE"] = filepath.Join(home.UserHomePath, ".gofish")
 	case "windows":
-		expectedTank["GOFISH_CACHE"] = filepath.Join(gofish.UserHomePath, "AppData", "Local", "Fish")
+		expectedTank["GOFISH_CACHE"] = filepath.Join(home.UserHomePath, "AppData", "Local", "Fish")
 	}
 
 	tank := tank{}

--- a/cmd/gofish/update.go
+++ b/cmd/gofish/update.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/ohai"
 	"github.com/fishworks/gofish/pkg/rig/installer"
 	"github.com/gosuri/uitable"
@@ -25,7 +25,7 @@ func newUpdateCmd() *cobra.Command {
 
 func updateRigs() error {
 	start := time.Now()
-	home := gofish.Home(gofish.HomePath)
+	home := home.Home(home.HomePath)
 	rigs := findRigs(home.Rigs())
 	for _, rig := range rigs {
 		i, err := installer.FindSource(filepath.Join(home.Rigs(), rig), home)

--- a/cmd/gofish/upgrade.go
+++ b/cmd/gofish/upgrade.go
@@ -25,6 +25,7 @@ func newUpgradeCmd() *cobra.Command {
 			}
 			nothingUpgraded := true
 			for _, name := range foodNames {
+				fmt.Println(name)
 				installedVersions := findFoodVersions(name)
 				vs := make(semver.Collection, len(installedVersions))
 				for i, r := range installedVersions {

--- a/pkg/home/home.go
+++ b/pkg/home/home.go
@@ -1,4 +1,4 @@
-package gofish
+package home
 
 import (
 	"path"

--- a/pkg/home/home_darwin.go
+++ b/pkg/home/home_darwin.go
@@ -1,6 +1,6 @@
-// +build !windows,!darwin
+// +build darwin
 
-package gofish
+package home
 
 import (
 	"os"
@@ -17,5 +17,5 @@ var UserHomePath = os.Getenv("HOME")
 
 // Cache returns the path to the cache.
 func (h UserHome) Cache() string {
-	return h.Path(".gofish")
+	return h.Path("Library", "Caches", "Fish")
 }

--- a/pkg/home/home_unix.go
+++ b/pkg/home/home_unix.go
@@ -1,6 +1,6 @@
-// +build darwin
+// +build !windows,!darwin
 
-package gofish
+package home
 
 import (
 	"os"
@@ -17,5 +17,5 @@ var UserHomePath = os.Getenv("HOME")
 
 // Cache returns the path to the cache.
 func (h UserHome) Cache() string {
-	return h.Path("Library", "Caches", "Fish")
+	return h.Path(".gofish")
 }

--- a/pkg/home/home_windows.go
+++ b/pkg/home/home_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package gofish
+package home
 
 import (
 	"os"

--- a/pkg/rig/installer/installer.go
+++ b/pkg/rig/installer/installer.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/rig"
 )
 
@@ -44,7 +44,7 @@ func Update(i Installer) error {
 }
 
 // FindSource determines the correct Installer for the given source.
-func FindSource(location string, home gofish.Home) (Installer, error) {
+func FindSource(location string, home home.Home) (Installer, error) {
 	installer, err := existingVCSRepo(location, home)
 	if err != nil && err.Error() == "Cannot detect VCS" {
 		return installer, rig.ErrMissingSource
@@ -53,7 +53,7 @@ func FindSource(location string, home gofish.Home) (Installer, error) {
 }
 
 // New determines and returns the correct Installer for the given source
-func New(source, name, version string, home gofish.Home) (Installer, error) {
+func New(source, name, version string, home home.Home) (Installer, error) {
 	if isLocalReference(source) {
 		return NewLocalInstaller(source, name, home)
 	}

--- a/pkg/rig/installer/local_installer.go
+++ b/pkg/rig/installer/local_installer.go
@@ -4,19 +4,19 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/rig"
 )
 
 // LocalInstaller installs rigs from the filesystem
 type LocalInstaller struct {
 	Source string
-	Home   gofish.Home
+	Home   home.Home
 	Name   string
 }
 
 // NewLocalInstaller creates a new LocalInstaller
-func NewLocalInstaller(source string, name string, home gofish.Home) (*LocalInstaller, error) {
+func NewLocalInstaller(source string, name string, home home.Home) (*LocalInstaller, error) {
 	i := &LocalInstaller{
 		Source: source,
 		Home:   home,

--- a/pkg/rig/installer/local_installer_test.go
+++ b/pkg/rig/installer/local_installer_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 )
 
 var _ Installer = new(LocalInstaller)
@@ -17,7 +17,7 @@ func TestLocalInstaller(t *testing.T) {
 	}
 	defer os.RemoveAll(dh)
 
-	home := gofish.Home(dh)
+	home := home.Home(dh)
 	if err := os.MkdirAll(home.Rigs(), 0755); err != nil {
 		t.Fatalf("Could not create %s: %s", home.Rigs(), err)
 	}

--- a/pkg/rig/installer/vcs_installer.go
+++ b/pkg/rig/installer/vcs_installer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/Masterminds/vcs"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/rig"
 )
 
@@ -18,12 +18,12 @@ import (
 type VCSInstaller struct {
 	Version string
 	Source  string
-	Home    gofish.Home
+	Home    home.Home
 	Name    string
 }
 
 // NewVCSInstaller creates a new VCSInstaller.
-func NewVCSInstaller(source, name, version string, home gofish.Home) (*VCSInstaller, error) {
+func NewVCSInstaller(source, name, version string, home home.Home) (*VCSInstaller, error) {
 	i := &VCSInstaller{
 		Version: version,
 		Source:  source,
@@ -91,7 +91,7 @@ func (i *VCSInstaller) Update() error {
 	return nil
 }
 
-func existingVCSRepo(location string, home gofish.Home) (Installer, error) {
+func existingVCSRepo(location string, home home.Home) (Installer, error) {
 	repo, err := vcs.NewRepo("", location)
 	if err != nil {
 		return nil, err

--- a/pkg/rig/installer/vcs_installer_test.go
+++ b/pkg/rig/installer/vcs_installer_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/fishworks/gofish"
+	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/rig"
 )
 
@@ -19,7 +19,7 @@ func TestVCSInstallerSuccess(t *testing.T) {
 	}
 	defer os.RemoveAll(dh)
 
-	home := gofish.Home(dh)
+	home := home.Home(dh)
 	if err := os.MkdirAll(home.Rigs(), 0755); err != nil {
 		t.Fatalf("Could not create %s: %s", home.Rigs(), err)
 	}
@@ -65,7 +65,7 @@ func TestVCSInstallerUpdate(t *testing.T) {
 	}
 	defer os.RemoveAll(dh)
 
-	home := gofish.Home(dh)
+	home := home.Home(dh)
 	if err := os.MkdirAll(home.Rigs(), 0755); err != nil {
 		t.Fatalf("Could not create %s: %s", home.Rigs(), err)
 	}

--- a/receipt/install_receipt.go
+++ b/receipt/install_receipt.go
@@ -1,0 +1,38 @@
+package receipt
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+const ReceiptFilename = "INSTALL_RECEIPT.json"
+
+type InstallReceipt struct {
+	// The name of the food installed
+	Name string `json:"name"`
+	// Which rig did this food come from?
+	Rig string `json:"rig"`
+	// Time that this food was last modified (upgraded)
+	LastModified time.Time `json:"last-modified"`
+	// What version of GoFish was this last modified with?
+	GoFishVersion string `json:"gofish-version"`
+}
+
+// NewFromReader reads in an install receipt from an io.Reader. Useful when reading from a file stream.
+func NewFromReader(r io.Reader) (*InstallReceipt, error) {
+	var receipt InstallReceipt
+	err := json.NewDecoder(r).Decode(&receipt)
+	return &receipt, err
+}
+
+// Save writes the install receipt into the given io.Writer.
+func (i *InstallReceipt) Save(w io.Writer) error {
+	data, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	w.Write([]byte("\n"))
+	return err
+}

--- a/receipt/install_receipt_test.go
+++ b/receipt/install_receipt_test.go
@@ -1,0 +1,28 @@
+package receipt
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewFromReader(t *testing.T) {
+	buf := bytes.NewBufferString("{}")
+	r, err := NewFromReader(buf)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := InstallReceipt{}
+	if *r != expected {
+		t.Errorf("expected to load an empty install receipt")
+	}
+
+	buf = bytes.NewBufferString(`{"name": "foo"}`)
+	r, err = NewFromReader(buf)
+	if err != nil {
+		t.Error(err)
+	}
+	expected.Name = "foo"
+	if *r != expected {
+		t.Errorf("expected '%v', got '%v'", expected, *r)
+	}
+}


### PR DESCRIPTION
This change records an install receipt any time the food is installed or upgraded, allowing future installs to get the right rig name.

This requires a re-install of all food installed locally for the change to take effect.

closes #113

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>