### PR TITLE
Add support for more archive formats

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,14 +18,6 @@
   version = "v1.12.0"
 
 [[projects]]
-  digest = "1:6331095c1906771fbe129fe4a1f94ac5b5a97b0f60f2f80653bb95c3e5dad81e"
-  name = "github.com/Microsoft/go-winio"
-  packages = ["."]
-  pruneopts = ""
-  revision = "7da180ee92d8bd8bb8c37fc560e673e6557c392f"
-  version = "v0.4.7"
-
-[[projects]]
   digest = "1:67363874cb9ef800804cbd9cdd853953c3826ae1511011cd3467ab331ca3c63d"
   name = "github.com/andybalholm/brotli"
   packages = ["."]
@@ -40,39 +32,6 @@
   pruneopts = ""
   revision = "792d0443b3e34e0a99a68e254084079ad9356db5"
   version = "v1.0.1"
-
-[[projects]]
-  branch = "master"
-  digest = "1:96843e93d86862260d76d1ba589e988b62be6aa26fb8eb7e0d9d301c33fc194f"
-  name = "github.com/containerd/continuity"
-  packages = ["pathdriver"]
-  pruneopts = ""
-  revision = "c6cef34830231743494fe2969284df7b82cc0ad0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:b5dd3e0b0bab1ee60331d1528636de395900879f8ae026461cb7eb45e08c1088"
-  name = "github.com/docker/docker"
-  packages = [
-    "pkg/archive",
-    "pkg/fileutils",
-    "pkg/idtools",
-    "pkg/ioutils",
-    "pkg/longpath",
-    "pkg/mount",
-    "pkg/pools",
-    "pkg/system",
-  ]
-  pruneopts = ""
-  revision = "cf9c48bb3ecf47ed56a4b7b466eda577913f838e"
-
-[[projects]]
-  digest = "1:582d54fcb7233da8dde1dfd2210a5b9675d0685f84246a8d317b07d680c18b1b"
-  name = "github.com/docker/go-units"
-  packages = ["."]
-  pruneopts = ""
-  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
-  version = "v0.3.3"
 
 [[projects]]
   digest = "1:ba9a3ee3359edeeec2c6c1ddb6976db4b7ca6ad045e73b43471e32f01b5786e4"
@@ -181,36 +140,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:5d9b668b0b4581a978f07e7d2e3314af18eb27b3fb5d19b70185b7c575723d11"
-  name = "github.com/opencontainers/go-digest"
-  packages = ["."]
-  pruneopts = ""
-  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
-  version = "v1.0.0-rc1"
-
-[[projects]]
-  digest = "1:f26c8670b11e29a49c8e45f7ec7f2d5bac62e8fd4e3c0ae1662baa4a697f984a"
-  name = "github.com/opencontainers/image-spec"
-  packages = [
-    "specs-go",
-    "specs-go/v1",
-  ]
-  pruneopts = ""
-  revision = "d60099175f88c47cd379c4738d158884749ed235"
-  version = "v1.0.1"
-
-[[projects]]
-  digest = "1:fa19ddee0e5ee5951a6a450a4b6ec635a42957f86bfc87d9d778eeee04ad2036"
-  name = "github.com/opencontainers/runc"
-  packages = [
-    "libcontainer/system",
-    "libcontainer/user",
-  ]
-  pruneopts = ""
-  revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
-  version = "v0.1.1"
-
-[[projects]]
   digest = "1:9acd22bf007b5c9a85af260b7abf6b7e02e0bfac256a51b6cefefabad59de183"
   name = "github.com/pierrec/lz4"
   packages = [
@@ -220,14 +149,6 @@
   pruneopts = ""
   revision = "edce7c4c96dac9adc01d38b18fd2456a7c0c5773"
   version = "v2.4.1"
-
-[[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  pruneopts = ""
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
 
 [[projects]]
   digest = "1:54b56e41fbe67fa032aef3c985939ca17a61f0c21fd81aee753018f8f3f70889"
@@ -313,14 +234,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:80ec738f420f13c23460cc92cd893d3e403588c60682afebbd4515eca5e19578"
-  name = "golang.org/x/net"
-  packages = ["context"]
-  pruneopts = ""
-  revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
-
-[[projects]]
-  branch = "master"
   digest = "1:e947dc04c62cf4cca2b3b137d3f266fb592f5de429b9e18c0c3018df0eb78c76"
   name = "golang.org/x/sys"
   packages = [
@@ -337,7 +250,6 @@
     "github.com/Masterminds/semver",
     "github.com/Masterminds/vcs",
     "github.com/bacongobbler/browser",
-    "github.com/docker/docker/pkg/archive",
     "github.com/gosuri/uitable",
     "github.com/kyokomi/emoji",
     "github.com/mholt/archiver",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,14 @@
   version = "v0.4.7"
 
 [[projects]]
+  digest = "1:67363874cb9ef800804cbd9cdd853953c3826ae1511011cd3467ab331ca3c63d"
+  name = "github.com/andybalholm/brotli"
+  packages = ["."]
+  pruneopts = ""
+  revision = "b60f0d972eeb79a5fba5fb60f1e0568bc8c97e42"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:9d013c04ff3012769abc7ea289948bf93bf82e8b22c5909f031127647609523f"
   name = "github.com/bacongobbler/browser"
   packages = ["."]
@@ -43,7 +51,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5fcfd7c83aa89c5cbe9682f04306c8745cf7c8ea1b3d8467253efcb5b6775394"
+  digest = "1:b5dd3e0b0bab1ee60331d1528636de395900879f8ae026461cb7eb45e08c1088"
   name = "github.com/docker/docker"
   packages = [
     "pkg/archive",
@@ -67,6 +75,29 @@
   version = "v0.3.3"
 
 [[projects]]
+  digest = "1:ba9a3ee3359edeeec2c6c1ddb6976db4b7ca6ad045e73b43471e32f01b5786e4"
+  name = "github.com/dsnet/compress"
+  packages = [
+    ".",
+    "bzip2",
+    "bzip2/internal/sais",
+    "internal",
+    "internal/errors",
+    "internal/prefix",
+  ]
+  pruneopts = ""
+  revision = "da652975a8eea9fa0735aba8056747a751db0bd3"
+  version = "v0.0.1"
+
+[[projects]]
+  digest = "1:6a6322a15aa8e99bd156fbba0aae4e5d67b4bb05251d860b348a45dfdcba9cce"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:b4e7b1e55d849b7d1a4d96d1a029141d7ac963b4403e6ddb1cdb6e5384ab4781"
   name = "github.com/gosuri/uitable"
@@ -87,6 +118,29 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:869328e75483b90d94966c4355ef737c3f311b0627db1d37612d97d6896da405"
+  name = "github.com/klauspost/compress"
+  packages = [
+    "flate",
+    "fse",
+    "huff0",
+    "snappy",
+    "zstd",
+    "zstd/internal/xxhash",
+  ]
+  pruneopts = ""
+  revision = "459b83aadb42b806aed42f0f4b3240c8834e0cc1"
+  version = "v1.9.8"
+
+[[projects]]
+  digest = "1:0a36eb96ea34a66384e17bf1927f42ffa5856ffcae35561ff7936f968c43776a"
+  name = "github.com/klauspost/pgzip"
+  packages = ["."]
+  pruneopts = ""
+  revision = "083b1c3f84dd6486588802e5ce295de3a7f41a8b"
+  version = "v1.2.1"
+
+[[projects]]
   branch = "master"
   digest = "1:41ea0e53c25c1c7f51b3ff6589bcf586a0fb548caceeb6a5dd60b91ed19ea801"
   name = "github.com/kyokomi/emoji"
@@ -103,12 +157,28 @@
   version = "v0.0.2"
 
 [[projects]]
+  digest = "1:d0612e2ce73b9236d3986923e0d474f276d8c57183047752c48894750e7be125"
+  name = "github.com/mholt/archiver"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3bd45bda8a6db94a901d9f39983d3b2298438e43"
+  version = "v3.3.0"
+
+[[projects]]
   branch = "master"
   digest = "1:59fa50d593e5673a0dfffa1852b66fd700c05b35e368680b4b89a68fdb2c1379"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = ""
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+
+[[projects]]
+  digest = "1:b93a939355dc613ca1c23bf39f6d4c207da431a31dd8af001cc334ad24cab9d3"
+  name = "github.com/nwaples/rardecode"
+  packages = ["."]
+  pruneopts = ""
+  revision = "cc3e4b2381762c56dbcdf9f93be03349a1dc1c14"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:5d9b668b0b4581a978f07e7d2e3314af18eb27b3fb5d19b70185b7c575723d11"
@@ -139,6 +209,17 @@
   pruneopts = ""
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
+
+[[projects]]
+  digest = "1:9acd22bf007b5c9a85af260b7abf6b7e02e0bfac256a51b6cefefabad59de183"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = ""
+  revision = "edce7c4c96dac9adc01d38b18fd2456a7c0c5773"
+  version = "v2.4.1"
 
 [[projects]]
   digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
@@ -179,6 +260,27 @@
   pruneopts = ""
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:cc4c87dc4fa2a87abd2a0901cbd8c0ca10a4a83929d62947de0ad111ab830e01"
+  name = "github.com/ulikunitz/xz"
+  packages = [
+    ".",
+    "internal/hash",
+    "internal/xlog",
+    "lzma",
+  ]
+  pruneopts = ""
+  revision = "6f934d456d51e742b4eeab20d925a827ef22320a"
+  version = "v0.5.6"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5d5ea0c53c32b0465b910eb1d98b045c2f14c416880c54dd5356a1c6b4569041"
+  name = "github.com/xi2/xz"
+  packages = ["."]
+  pruneopts = ""
+  revision = "48954b6210f8d154cb5f8484d3a3e1f83489309e"
 
 [[projects]]
   branch = "master"
@@ -238,6 +340,7 @@
     "github.com/docker/docker/pkg/archive",
     "github.com/gosuri/uitable",
     "github.com/kyokomi/emoji",
+    "github.com/mholt/archiver",
     "github.com/renstrom/fuzzysearch/fuzzy",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,10 +27,6 @@
   version = "v0.0.1"
 
 [[constraint]]
-  name = "github.com/docker/docker"
-  branch = "master"
-
-[[constraint]]
   name = "github.com/kyokomi/emoji"
   branch = "master"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,3 +33,7 @@
 [[constraint]]
   name = "github.com/kyokomi/emoji"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/mholt/archiver"
+  version = "3.3.0"

--- a/food.go
+++ b/food.go
@@ -175,14 +175,7 @@ func (f *Food) Uninstall() error {
 }
 
 func unarchiveOrCopy(src, dest, urlPath string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	err = archiver.Unarchive(src, dest)
-	if err == nil {
+	if err := archiver.Unarchive(src, dest); err == nil {
 		return nil
 	}
 	out, err := os.Create(filepath.Join(dest, filepath.Base(urlPath)))

--- a/food.go
+++ b/food.go
@@ -175,7 +175,13 @@ func (f *Food) Uninstall() error {
 }
 
 func unarchiveOrCopy(src, dest, urlPath string) error {
-	if err := archiver.Unarchive(src, dest); err == nil; {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := archiver.Unarchive(src, dest); err == nil {
 		return nil
 	}
 	out, err := os.Create(filepath.Join(dest, filepath.Base(urlPath)))

--- a/food.go
+++ b/food.go
@@ -1,7 +1,6 @@
 package gofish
 
 import (
-	"archive/zip"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -322,41 +321,6 @@ func downloadCachedFileToPath(filePath string, url string) error {
 
 	_, err = io.Copy(out, resp.Body)
 	return err
-}
-
-func isZipPath(path string) bool {
-	_, err := zip.OpenReader(path)
-	return err == nil
-}
-
-func unzip(src, dest string) error {
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	for _, zf := range r.File {
-		if zf.FileHeader.FileInfo().IsDir() {
-			if err := os.Mkdir(filepath.Join(dest, zf.Name), 0755); err != nil {
-				return err
-			}
-			continue
-		}
-		dst, err := os.Create(filepath.Join(dest, zf.Name))
-		if err != nil {
-			return err
-		}
-		defer dst.Close()
-		src, err := zf.Open()
-		if err != nil {
-			return err
-		}
-		defer src.Close()
-
-		io.Copy(dst, src)
-	}
-	return nil
 }
 
 func checksumVerifyPath(path string, checksum string) error {

--- a/food.go
+++ b/food.go
@@ -15,11 +15,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/pkg/archive"
 	"github.com/fishworks/gofish/pkg/home"
 	"github.com/fishworks/gofish/pkg/osutil"
 	"github.com/fishworks/gofish/receipt"
 	"github.com/fishworks/gofish/version"
+	"github.com/mholt/archiver"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -182,11 +182,9 @@ func unarchiveOrCopy(src, dest, urlPath string) error {
 	}
 	defer in.Close()
 
-	if archive.IsArchivePath(src) {
-		return archive.Untar(in, dest, &archive.TarOptions{NoLchown: true})
-	} else if isZipPath(src) {
-		in.Close()
-		return unzip(src, dest)
+	err = archiver.Unarchive(src, dest)
+	if err == nil {
+		return nil
 	}
 	out, err := os.Create(filepath.Join(dest, filepath.Base(urlPath)))
 	if err != nil {

--- a/food.go
+++ b/food.go
@@ -175,15 +175,15 @@ func (f *Food) Uninstall() error {
 }
 
 func unarchiveOrCopy(src, dest, urlPath string) error {
+	if err := archiver.Unarchive(src, dest); err == nil {
+		return nil
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
-
-	if err := archiver.Unarchive(src, dest); err == nil {
-		return nil
-	}
 	out, err := os.Create(filepath.Join(dest, filepath.Base(urlPath)))
 	if err != nil {
 		return err

--- a/food.go
+++ b/food.go
@@ -175,7 +175,7 @@ func (f *Food) Uninstall() error {
 }
 
 func unarchiveOrCopy(src, dest, urlPath string) error {
-	if err := archiver.Unarchive(src, dest); err == nil {
+	if err := archiver.Unarchive(src, dest); err == nil; {
 		return nil
 	}
 	out, err := os.Create(filepath.Join(dest, filepath.Base(urlPath)))


### PR DESCRIPTION
Not sure if this works, it seems that gofish is still using the old unarchiving code

My setup:

```
cd %USERPROFILE%\go\src\github.com\fishworks
git clone https://github.com/fishworks/gofish
cd gofish
dep ensure
cd cmd\gofish
go run . install cabal-install
```