### PR TITLE
Minor install.sh fix: replaced tar xf with tar -zxf

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,7 +98,7 @@ downloadFile() {
 installFile() {
   TMPDIR="/tmp/$PROJECT_NAME"
   mkdir -p "$TMPDIR"
-  tar xf "$TMP_CACHE_FILE" -C "$TMPDIR"
+  tar -zxf "$TMP_CACHE_FILE" -C "$TMPDIR"
   echo "Preparing to install into ${INSTALL_PREFIX}"
   # Use * to also copy the file withe the exe suffix on Windows
   sudo mkdir -p "$INSTALL_PREFIX"


### PR DESCRIPTION
Rationale: curl command failed on tar when installing

OS: Darwin 19.6.0 Darwin Kernel Version 19.6.0: Sun Jul  5 00:43:10 PDT 2020; root:xnu-6153.141.1~9/RELEASE_X86_64

Error:
➜  ~ curl -fsSL https://raw.githubusercontent.com/fishworks/gofish/master/scripts/install.sh | bash
Downloading https://gofi.sh/releases/gofish-v0.13.0-macos-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   837    0   837    0     0   2021      0 --:--:-- --:--:-- --:--:--  2021
tar: Error opening archive: Unrecognized archive format
!!!     Failed to install gofish
!!!     For support, go to https://github.com/fishworks/gofish.

➜  ~ curl -fsSL https://raw.githubusercontent.com/fishworks/gofish/master/scripts/install.sh | zsh
Downloading https://gofi.sh/releases/gofish-v0.13.0-macos-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   837    0   837    0     0   4382      0 --:--:-- --:--:-- --:--:--  4382
tar: Error opening archive: Unrecognized archive format

Fix:
➜  Downloads zsh install.sh 
Downloading https://gofi.sh/releases/gofish-v0.12.2-macos-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8624k  100 8624k    0     0  4575k      0  0:00:01  0:00:01 --:--:-- 4573k
Preparing to install into /usr/local/bin
Password:
gofish installed into /usr/local/bin/gofish
Run 'gofish init' to get started!

➜  Downloads gofish init
The following new directories will be created:
/usr/local/gofish
/usr/local/gofish/Barrel
/usr/local/gofish/Rigs
/usr/local/bin
/Users/erikmaldonado/Library/Caches/gofish
==> Installing default fish food...
🐠  rig constructed in 1.968466143s