### PR TITLE
(proof of concept) install.go: replace lua with ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 vendor
 _dist
+libmruby.a

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TAGS      :=
 LDFLAGS   :=
 GOFLAGS   :=
 BINDIR    := $(CURDIR)/bin
+VENDORDIR := $(CURDIR)/vendor
 
 # Required for globs to work correctly
 SHELL=/bin/bash
@@ -13,11 +14,18 @@ SHELL=/bin/bash
 .PHONY: all
 all: $(BINDIR)/$(BIN_NAME)
 
-$(BINDIR)/$(BIN_NAME):
+$(BINDIR)/$(BIN_NAME): libmruby.a
 	$(GO) build -o $(BINDIR)/$(BIN_NAME) $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/$(BIN_NAME)
+
+libmruby.a:
+	go mod vendor
+	cd vendor/github.com/SeekingMeaning/go-mruby && make libmruby.a
+	cp vendor/github.com/SeekingMeaning/go-mruby/libmruby.a .
 
 .PHONY: clean
 clean:
 	@rm -rf $(BINDIR)
+	@rm -rf $(VENDORDIR)
+	@rm -rf libmruby.a
 
 include versioning.mk

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/vcs v1.13.1
+	github.com/SeekingMeaning/go-mruby v0.0.0-20200802182122-533070ae21cd
 	github.com/bacongobbler/browser v1.1.0
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/frankban/quicktest v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/vcs v1.13.1 h1:NL3G1X7/7xduQtA2sJLpVpfHTNBALVNSjob6KEjPXNQ=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/SeekingMeaning/go-mruby v0.0.0-20200802182122-533070ae21cd h1:GOxYiqSJ67g+/yh71IyyYpFWIgWi6J1NO03Mq6MVg8g=
+github.com/SeekingMeaning/go-mruby v0.0.0-20200802182122-533070ae21cd/go.mod h1:suI7TlsPLIINgZK/SenZ6Ja/PdxNJBIgBYEIfDh54gk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 h1:bZ28Hqta7TFAK3Q08CMvv8y3/8ATaEqv2nGoc6yff6c=


### PR DESCRIPTION
- This replaces `yuin/gopher-lua` and `yuin/gluamapper` with [`mitchellh/go-mruby`](https://github.com/mitchellh/go-mruby)
- Depends on mitchellh/go-mruby#79
  - This PR uses the [`optional-fields`](https://github.com/SeekingMeaning/go-mruby/tree/optional-fields) branch of [`SeekingMeaning/go-mruby`](https://github.com/SeekingMeaning/go-mruby)
- Vendoring of `go-mruby` based on https://github.com/mikesimons/yaml-dsl
- ~~Haven't tested this with a fresh git clone~~

Example food `aks-engine.rb` using ruby DSL:
https://gist.github.com/SeekingMeaning/8b81f7a1fbbacfab68889f95ab1bd5f0

```rb
food do
  name 'aks-engine'
  description 'Azure Kubernetes Engine - a place for the community to collaborate and build the best Kubernetes infrastructure for Azure'
  license 'MIT'
  homepage 'https://github.com/Azure/aks-engine'
  version '0.53.0'

  package do
    os 'darwin'
    arch 'amd64'
    url "https://github.com/Azure/#{name}/releases/download/v#{version}/#{name}-v#{version}-#{os}-#{arch}.tar.gz"
    sha256 '9753ae612760d1572fb77e12c5c365202aa18d98a1c8c6dd433b911f4a3fa320'
    resource do
      path "#{name}-v#{version}-#{os}-#{arch}/#{name}"
      installpath "bin/#{name}"
      executable true
    end
  end

  ...
```

~~Example ruby food `gofish.rb`:~~
~~https://gist.github.com/SeekingMeaning/816462e3f66c961303208a2ac0c9e7b5~~

~~Example food using mitchellh/go-mruby#78 syntax:~~
~~https://gist.github.com/SeekingMeaning/8c701210400bd27edfaa06603a97ba9b~~

Note: This pull request is mostly just a proof of concept