### PR TITLE
Create symlinks under $GOFISH_BINPATH

### DIFF
--- a/food.go
+++ b/food.go
@@ -246,7 +246,14 @@ func (f *Food) Link(pkg *Package) error {
 	barrelDir := filepath.Join(home.Barrel(), f.Name, f.Version)
 	for _, r := range pkg.Resources {
 		// TODO: run this in parallel
-		destPath := filepath.Join(home.HomePrefix, r.InstallPath)
+
+		// We assume every Food's InstallPath begins with `bin/` (`bin\\` on Windows)
+		installPath, err := filepath.Rel("bin", r.InstallPath)
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(home.BinPath(), installPath)
 		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil && !os.IsExist(err) {
 			return err
 		}

--- a/food.go
+++ b/food.go
@@ -272,8 +272,16 @@ func (f *Food) Link(pkg *Package) error {
 // Unlink removes any linked resources owned by the package.
 func (f *Food) Unlink(pkg *Package) error {
 	for _, r := range pkg.Resources {
+		// We assume every Food's InstallPath begins with `bin/` (`bin\\` on Windows)
+		installPath, err := filepath.Rel("bin", r.InstallPath)
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(home.BinPath(), installPath)
+
 		// TODO: check if the linked path we are about to remove is really owned by us
-		if err := os.RemoveAll(filepath.Join(home.HomePrefix, r.InstallPath)); err != nil {
+		if err := os.RemoveAll(destPath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This fixes `go-fish install` to use `$GOFISH_BINPATH` when installing foods.

To be clear, `go-fish init` had been correctly using `$GOFISH_BINPATH` to override the default bin path(e.g. `/usr/local/bin` on *nix) to be created. So, I had expected `go-fish install` to install binaries under the path `go-fish init` created, but it didn't.

This patch updates `gofish install` to create symlinks under `$GOFISH_BINPATH` if set, so that the behavior is consistent with `init`.