### PR TITLE
Annotate semver error on upgrade

### DIFF
--- a/cmd/gofish/upgrade.go
+++ b/cmd/gofish/upgrade.go
@@ -34,6 +34,7 @@ func newUpgradeCmd() *cobra.Command {
 				for i, r := range installedVersions {
 					v, err := semver.NewVersion(r)
 					if err != nil {
+						ohai.Ohaif("Upgrading %s...\n", name)
 						return fmt.Errorf("Error parsing version: %v", err)
 					}
 					vs[i] = v


### PR DESCRIPTION
Adds the string of the package name to the semver error string, if the semver cannot be parsed.

The semver parsing happens before an upgrade begins as it compares the installed version in the Barrel versus the parsed version from the Food.

Looks like:

```console
==> Rigs updated!
NAME
github.com/arbourd/rig
github.com/fishworks/fish-food

🐠  rigs updated in 1.932896584s
==> Upgrading tilt...
🐠  tilt 0.17.6: upgraded in 50.108867ms
==> Upgrading trash...
Error: Error parsing version: Invalid Semantic Version
```

Closes #166