### PR TITLE
Fix test.yml actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     - name: build
       run: make
     - name: run style tests
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.26
+        version: v1.34
         args: --tests --disable-all --enable=gofmt --enable=misspell --enable=deadcode --enable=ineffassign --enable=govet
     - name: run unit tests
       run: go test ./...


### PR DESCRIPTION
- Updates golangci-lint-action to v2 which fixes `set-env` errors (deprecated by Github)
- Update golangci-lint to 1.34 (tested, passes, no changes)
  golangci-lint must be updated to greater than 1.28.3 for action@v2

```console
$ golangci-lint version
golangci-lint has version 1.34.1 built from d7dd233 on 2020-12-29T06:20:54Z
$ golangci-lint run --out-format=github-actions --tests --disable-all --enable=gofmt --enable=misspell --enable=deadcode --enable=ineffassign --enable=govet
```