### PR TITLE
Fix build.yml action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
 
     - name: set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
     - name: set the release version (main)
       if: github.ref == 'refs/heads/main'
-      run: echo ::set-env name=RELEASE_VERSION::canary
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - uses: actions/setup-go@v2
       with:
@@ -60,11 +60,11 @@ jobs:
     steps:
       - name: set the release version
         if: startsWith(github.ref, 'refs/tags/v')
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: set the release version
         if: github.ref == 'refs/heads/main'
-        run: echo ::set-env name=RELEASE_VERSION::canary
+        run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
       - name: download release assets
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Uses GITHUB_ENV file over deprecated `set-env` command.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/