### PR TITLE
Sort by SemVer before getting the latest version

### DIFF
--- a/cmd/gofish/upgrade.go
+++ b/cmd/gofish/upgrade.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"time"
+	"sort"
 
 	"github.com/Masterminds/semver"
 	"github.com/fishworks/gofish/pkg/ohai"
@@ -39,6 +40,7 @@ func newUpgradeCmd() *cobra.Command {
 					}
 					vs[i] = v
 				}
+				sort.Sort(vs)
 				// we can safely assume there's at least one release installed
 				latestInstalledVersion := vs[len(vs)-1]
 				food, err := getFood(name)


### PR DESCRIPTION
`vs` contains alphabetically sorted versions (it's generated from `ioutil.ReadDir`) so e.g. `0.9.0` appears to be greater than `0.13.4` (particular case for `flux` fish food at the moment).
`semver.Collection` implements sort interface so we can get the latest version easily.