### PR TITLE
Add linting that tests that the actual binary exists

### DIFF
--- a/food.go
+++ b/food.go
@@ -326,7 +326,7 @@ func installVerify(f *Food, pkg *Package, src string) error {
 	for _, r := range pkg.Resources {
 		rPath := r.Path
 		// If we are validating windows packages on a non-windows machine
-		// we need to change the directory seperator
+		// we need to change the directory separator
 		if runtime.GOOS != "windows" {
 			strings.ReplaceAll(r.Path, "\\", "/")
 		}


### PR DESCRIPTION
Checking that all referenced resources/binaries/executables exists in the given archive file or at the given path.
Extracted from gofish-bot.

Fixes: https://github.com/fishworks/fish-food/issues/1124

I have been using this extended linting to find multiple old problems in different fish-foods.
So all current fish-foods should parse the linting.