### PR TITLE
Download file should ensure directory exists

### DIFF
--- a/food.go
+++ b/food.go
@@ -337,6 +337,18 @@ func downloadCachedFileToPath(filePath string, url string) error {
 		return err
 	}
 
+	// ensure directory exist
+	dirPath := filepath.Dir(filePath)
+	if _, err = os.Stat(dirPath); err != nil {
+		if os.IsNotExist(err) {
+			if err = os.MkdirAll(dirPath, 0755); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
 	if _, err = os.Stat(filePath); err == nil {
 		return nil
 	}


### PR DESCRIPTION
When I upgraded go 1.16.5, I got the following output:

```
==> Installing go...
Error: failed to download package for OS/arch darwin/amd64 with URL https://dl.google.com/go/go1.16.5.darwin-amd64.tar.gz to filepath /Users/Dreamacro/Library/Caches/gofish/go-1.16.5-darwin-amd64.tar.gz
```

I tried to uninstall go, or anything I thought might help, but nothing worked.

Finally, I run `mkdir /Users/Dreamacro/Library/Caches/gofish` and everything work again. Maybe the cache directory was cleaned by another tool.

So I think it should ensure directory exists before download