### PR TITLE
Detect root (uid 0) and bypass sudo.

### DIFF
--- a/cmd/gofish/ensure_unix.go
+++ b/cmd/gofish/ensure_unix.go
@@ -10,11 +10,24 @@ import (
 )
 
 func ensureDirectories(dirs []string) error {
+	var isRoot bool = false
+
 	userCmd := exec.Command("id", "-un")
 	userOutput, err := userCmd.Output()
 	if err != nil {
 		return err
 	}
+
+	userCmd = exec.Command("id", "-u")
+	userId, err := userCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSuffix(string(userId), "\n") == "0" {
+		isRoot = true
+	}
+
 	// strip the newline character from the end
 	curUser := strings.TrimSuffix(string(userOutput), "\n")
 
@@ -23,14 +36,20 @@ func ensureDirectories(dirs []string) error {
 	if err != nil {
 		return err
 	}
+
 	// strip the newline character from the end
 	curGroup := strings.TrimSuffix(string(groupOutput), "\n")
 
 	fmt.Printf("The following new directories will be created:\n")
 	fmt.Println(strings.Join(dirs, "\n"))
+	var cmd *exec.Cmd
 	for _, dir := range dirs {
 		if fi, err := os.Stat(dir); err != nil {
-			cmd := exec.Command("sudo", "mkdir", dir)
+			if isRoot {
+				cmd = exec.Command("mkdir", dir)
+			} else {
+				cmd = exec.Command("sudo", "mkdir", dir)
+			}
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {
@@ -39,7 +58,11 @@ func ensureDirectories(dirs []string) error {
 		} else if !fi.IsDir() {
 			return fmt.Errorf("%s must be a directory", dir)
 		}
-		cmd := exec.Command("sudo", "chown", fmt.Sprintf("%s:%s", curUser, curGroup), dir)
+		if isRoot {
+			cmd = exec.Command("chown", fmt.Sprintf("%s:%s", curUser, curGroup), dir)
+		} else {
+			cmd = exec.Command("sudo", "chown", fmt.Sprintf("%s:%s", curUser, curGroup), dir)
+		}
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
This change allows gofish to run at root (uid 0).  Useful when used within Docker, while also retaining sudo usage when not run as root.