### PR TITLE
Add darwin-arm64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: build release assets
       run: |
         mkdir _dist
-        CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le windows/amd64' -ldflags "-X github.com/fishworks/gofish/version.Version=${{ env.RELEASE_VERSION }} -X github.com/fishworks/gofish/version.BuildMetadata=git.${GITHUB_SHA}" github.com/fishworks/gofish/cmd/gofish
+        CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='darwin/amd64 darwin/arm64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le windows/amd64' -ldflags "-X github.com/fishworks/gofish/version.Version=${{ env.RELEASE_VERSION }} -X github.com/fishworks/gofish/version.BuildMetadata=git.${GITHUB_SHA}" github.com/fishworks/gofish/cmd/gofish
 
     - name: create archives
       run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-amd64\ndarwin-amd64\nwindows-amd64\nlinux-386\nlinux-arm\nlinux-arm64\nlinux-ppc64le"
+  local supported="linux-amd64\ndarwin-amd64\ndarwin-arm64\nwindows-amd64\nlinux-386\nlinux-arm\nlinux-arm64\nlinux-ppc64le"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuilt binary for ${OS}-${ARCH}."
     exit 1


### PR DESCRIPTION
Adds darwin-arm64 builds to gox (should work with 1.17 outta the box)
command and updates the install script to allow curling the bin.
