### PR TITLE
add --overwrite flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,5 +81,5 @@ jobs:
           source_dir: '.'
           container_name: '$web'
           connection_string: ${{ secrets.CONNECTIONSTRING }}
-          extra_args: "--destination-path releases"
+          extra_args: "--destination-path releases --overwrite"
           sync: false


### PR DESCRIPTION
A recent version of azure-cli prevents uploads to overwrite existing
objects without providing the --overwrite flag.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>